### PR TITLE
pass query params from syftbox url to the httpx request

### DIFF
--- a/fastsyftbox/http_bridge.py
+++ b/fastsyftbox/http_bridge.py
@@ -56,9 +56,13 @@ class SyftHTTPBridge:
             print("Error getting method Defaulting to POST", e)
             pass
 
+        headers = request.headers or {}
+        headers["X-Syft-URL"] = str(request.url)
+
         return await self.app_client.request(
             method=method,
             url=path,
             content=request.body,
             headers=request.headers,
+            params=request.url.query,
         )


### PR DESCRIPTION
This pull request updates the `fastsyftbox/http_bridge.py` file to enhance HTTP request handling. The most significant change is the addition of custom headers and query parameters to improve request forwarding.

Enhancements to HTTP request handling:

* [`fastsyftbox/http_bridge.py`](diffhunk://#diff-f38c0280a90aad650a493e65e641902b959776e716c123a4e0c88b50598676b2R59-R67): Added a custom header `X-Syft-URL` to include the request URL in forwarded requests and ensured query parameters from the original request URL are passed along.