### PR TITLE
update syft-event and syft-core to point to latest versions

### DIFF
--- a/fastsyftbox/app_template/requirements.txt
+++ b/fastsyftbox/app_template/requirements.txt
@@ -1,3 +1,3 @@
-syft-core==0.2.5
-syft-event==0.2.7
+syft-core==0.2.8
+syft-event==0.2.8
 fastsyftbox==0.1.18

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,8 @@ classifiers = [
 dependencies = [
     "fastapi>=0.115.12",
     "uvicorn>=0.34.2",
-    "syft-event>=0.2.7",
-    "syft-core>=0.2.5",  # syft-event anyway depends on syft-core (but we have a direct dep, so adding explicitly)
+    "syft-event>=0.2.8",
+    "syft-core>=0.2.8",  # syft-event anyway depends on syft-core (but we have a direct dep, so adding explicitly)
     "typer>=0.4.0",
     "httpx>=0.28.1",
 ]


### PR DESCRIPTION
This pull request updates dependencies across the project to ensure compatibility with newer versions. The most important changes involve upgrading `syft-core` and `syft-event` dependencies in both `requirements.txt` and `pyproject.toml`.

Dependency updates:

* [`fastsyftbox/app_template/requirements.txt`](diffhunk://#diff-2f2cd6785195a9a57b4816c8b4b549ce2369df9ff183473f2b885af18d039941L1-R2): Updated `syft-core` to version `0.2.8` and `syft-event` to version `0.2.8`.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L24-R25): Updated `syft-core` to version `0.2.8` and `syft-event` to version `0.2.8` in the `dependencies` list.
