### PR TITLE
Add configurable RPC message expiration parameter

### DIFF
--- a/fastsyftbox/fastsyftbox.py
+++ b/fastsyftbox/fastsyftbox.py
@@ -37,6 +37,7 @@ class FastSyftBox(FastAPI):
         lifespan: Optional[Callable[[Any], AsyncContextManager[None]]] = None,
         syftbox_endpoint_tags: Optional[list[str]] = None,
         include_syft_openapi: bool = True,
+        rpc_message_ttl: Optional[str] = None,
         **kwargs,
     ):
         self.app_name = app_name
@@ -50,6 +51,10 @@ class FastSyftBox(FastAPI):
         self.include_syft_openapi = include_syft_openapi
         self.current_dir = Path(__file__).parent
         self.rpc_debug_enabled = kwargs.pop("rpc_debug_enabled", False)
+
+        # RPC message TTL, default to 7 days if not provided
+        # If a specific TTL is provided, use it; otherwise, fall back to the default
+        self.rpc_message_ttl = rpc_message_ttl
 
         # Wrap user lifespan with bridge lifespan
         super().__init__(title=app_name, lifespan=self._combined_lifespan, **kwargs)
@@ -82,6 +87,7 @@ class FastSyftBox(FastAPI):
             http_client=app_client,
             included_endpoints=syft_endpoints + syft_docs_endpoints,
             syftbox_client=self.syftbox_client,
+            rpc_message_ttl=self.rpc_message_ttl,
         )
         self.bridge.start()
         self.bridge.syft_events.set_debug_mode(self.rpc_debug_enabled)

--- a/fastsyftbox/http_bridge.py
+++ b/fastsyftbox/http_bridge.py
@@ -23,6 +23,8 @@ logger.addHandler(handler)
 from fastsyftbox.constants import SYFT_FROM_HEADER, SYFT_URL_HEADER
 
 MAX_HTTP_TIMEOUT_SECONDS = 30
+MAX_RPC_MSG_TTL = "7d"
+RPC_MSG_CLEANUP_INTERVAL = "3h"
 
 
 class SyftHTTPBridge:
@@ -32,8 +34,16 @@ class SyftHTTPBridge:
         http_client: httpx.AsyncClient,
         included_endpoints: list[str],
         syftbox_client: Optional[Client] = None,
+        rpc_message_ttl: Optional[str] = None,
     ):
-        self.syft_events = SyftEvents(app_name, client=syftbox_client)
+        self.syft_events = SyftEvents(
+            app_name,
+            client=syftbox_client,
+            cleanup_expiry=rpc_message_ttl
+            if rpc_message_ttl is not None
+            else MAX_RPC_MSG_TTL,
+            cleanup_interval=RPC_MSG_CLEANUP_INTERVAL,
+        )
         self.included_endpoints = included_endpoints
         self.app_client = http_client  # Add the missing app_client attribute
 


### PR DESCRIPTION
Introduce the `rpc_message_ttl` parameter to `FastSyftBox` and `SyftHTTPBridge` to allow configurable message expiration, defaulting to 7 days if not specified.